### PR TITLE
Create cookie locally

### DIFF
--- a/mortgage_analytics/src/pages/Login.jsx
+++ b/mortgage_analytics/src/pages/Login.jsx
@@ -26,8 +26,9 @@ const Login = () => {
         },
         { withCredentials: true })
         .then((response) => {
-            if(response.data === "Cookie set successfully!"){
+            if('authToken' in response.data){
                 alert("Signed in successfully");
+				document.cookie = 'AuthToken=' + response.data['authToken']
                 window.location.href = './';
             }
         })


### PR DESCRIPTION
The backend generating the cookie for the frontend has caused a lot of issues with the deployment, this change assumes the backend doesn't send a cookie but just the JWT plainly. The frontend can then create the cookie itself from that.